### PR TITLE
Added changes to the events standard implementation

### DIFF
--- a/nft-contract/src/internal.rs
+++ b/nft-contract/src/internal.rs
@@ -210,7 +210,7 @@ impl Contract {
             authorized_id = Some(sender_id.to_string());
         }
 
-        // Construct the mint log as per the events standard.
+        // Construct the transfer log as per the events standard.
         let nft_transfer_log: EventLog = EventLog {
             // Standard name ("nep171").
             standard: NFT_STANDARD_NAME.to_string(),


### PR DESCRIPTION
- I will be keeping the events being fired in `internal_transfer`
- I will add events to `nft_resolve_transfer`
- `nft_resolve_transfer` now needs to take `memo` and `authorized_id`. 

These changes are based on the following discussion held in the NEAR NFT NEP 171 Standardization Working Group:

![image](https://user-images.githubusercontent.com/57506486/145724921-c3386759-e718-419a-8feb-eb60fa9c41df.png)
![image](https://user-images.githubusercontent.com/57506486/145724925-7056cd36-38c2-4238-9bf1-205e0f0a90dc.png)
