### PR TITLE
Consistency between nft_payout and nft_transfer_payout

### DIFF
--- a/nft-contract/src/royalty.rs
+++ b/nft-contract/src/royalty.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 pub trait NonFungibleTokenCore {
     //calculates the payout for a token given the passed in balance. This is a view method
-    fn nft_payout(&self, token_id: String, balance: U128, max_len_payout: u32) -> Payout;
+    fn nft_payout(&self, token_id: TokenId, balance: U128, max_len_payout: u32) -> Payout;
     
     //transfers the token to the receiver ID and returns the payout object that should be payed given the passed in balance. 
     fn nft_transfer_payout(

--- a/nft-contract/src/royalty.rs
+++ b/nft-contract/src/royalty.rs
@@ -20,7 +20,7 @@ pub trait NonFungibleTokenCore {
 impl NonFungibleTokenCore for Contract {
 
     //calculates the payout for a token given the passed in balance. This is a view method
-    fn nft_payout(&self, token_id: String, balance: U128, max_len_payout: u32) -> Payout {
+    fn nft_payout(&self, token_id: TokenId, balance: U128, max_len_payout: u32) -> Payout {
         //get the token object
 		let token = self.tokens_by_id.get(&token_id).expect("No token");
 


### PR DESCRIPTION
I'm assuming TokenId and String are interchangeable here.