### PR TITLE
Windows line ending formatting would break yarn build

### DIFF
--- a/nft-contract/build.sh
+++ b/nft-contract/build.sh
@@ -1,6 +1,2 @@
 #!/bin/bash
-set -e
-
-RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release
-mkdir -p ../out
-cp target/wasm32-unknown-unknown/release/*.wasm ../out/main.wasm
+set -e && rustup target add wasm32-unknown-unknown && cargo build --target wasm32-unknown-unknown --release && mkdir -p ../out && cp target/wasm32-unknown-unknown/release/*.wasm ../out/main.wasm

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "author": "Ben Kurrek",
     "license": "ISC",
     "scripts": {
-        "build": "cd nft-contract && ./build.sh && cd ../.."
+        "build": "cd nft-contract && bash build.sh && cd ../.."
     }
 }


### PR DESCRIPTION
Running yarn build from root would within WSL or bash shell in windows would: 

1. Break with error that ./build.sh is not found. **Fix**: this command in package.json was changed to bash build.sh ([SO Link](https://unix.stackexchange.com/questions/155838/shell-script-throws-a-not-found-error-when-run-from-a-sh-file-but-if-entered-ma))
2. Line ending formatting by windows in build.sh would cause commands to be executed erroneously in the shell. **Fix**: commands in build.sh are chained with && operators instead of new lines. 

rustup command in build.sh has also been added in case this command had not been previously executed when initializing machine environment during the beginning of the tutorial. 