### PR TITLE
add nft_token_metadata implementation (necessary for NFT to appear in wallet) 

### DIFF
--- a/nft-contract/src/metadata.rs
+++ b/nft-contract/src/metadata.rs
@@ -67,11 +67,18 @@ pub struct JsonToken {
 pub trait NonFungibleTokenMetadata {
     //view call for returning the contract metadata
     fn nft_metadata(&self) -> NFTContractMetadata;
+
+    //view call for returning the token metadata -- without this the token is not visible on any wallet!
+    fn nft_token_metadata(&self, token_id: TokenId) -> TokenMetadata;
 }
 
 #[near_bindgen]
 impl NonFungibleTokenMetadata for Contract {
     fn nft_metadata(&self) -> NFTContractMetadata {
         self.metadata.get().unwrap()
+    }
+
+    fn nft_token_metadata(&self, token_id: TokenId) -> TokenMetadata {
+        self.token_metadata_by_id.get(&token_id).unwrap()
     }
 }


### PR DESCRIPTION
I was following this [NFT tutorial](https://docs.near.org/tutorials/nfts/minting) and no matter what I do I could not get the NFTs that i was minting to show up in any of the wallets.

I traced the NEAR wallet code and found [this line](https://github.com/near/near-wallet/blob/1b4fcf0816bef36060a653ea58aa9b2bbcc23ec3/packages/frontend/src/services/NonFungibleTokens.js#L51C1-L51C5) 

which is calling `nft_token_metadata` function and that was causing a `wasm execution failed with error: MethodResolveError(MethodNotFound).`

I implemented this function on my contract and the NFT appeared on the wallet.